### PR TITLE
Add GitHub MCP POC demo HTML and JS files

### DIFF
--- a/github-mcp-poc.html
+++ b/github-mcp-poc.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+  <title>GitHub MCP POC</title>
+</head>
+<body>
+  <div id='output'></div>
+  <script src='github-mcp-poc.js'></script>
+</body>
+</html> 

--- a/github-mcp-poc.js
+++ b/github-mcp-poc.js
@@ -1,0 +1,1 @@
+document.getElementById('output').textContent = 'GitHub MCP server ongoing POC'; 


### PR DESCRIPTION
This PR adds a minimal HTML and JS demo for the GitHub MCP server ongoing POC. The HTML file loads a JS file that prints a status message to the page.