### PR TITLE
Add GitHub MCP server POC HTML and JS files

### DIFF
--- a/github-mcp-server-poc.html
+++ b/github-mcp-server-poc.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang='en'>
+  <head>
+    <meta charset='UTF-8' />
+    <meta name='viewport' content='width=device-width, initial-scale=1.0' />
+    <title>GitHub MCP Server POC</title>
+  </head>
+  <body>
+    <div id='output'></div>
+    <script src='github-mcp-server-poc.js'></script>
+  </body>
+</html> 

--- a/github-mcp-server-poc.js
+++ b/github-mcp-server-poc.js
@@ -1,0 +1,6 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const outputDiv = document.getElementById('output');
+  if (outputDiv) {
+    outputDiv.textContent = 'GitHub MCP server POC';
+  }
+}); 


### PR DESCRIPTION
This PR adds a minimal HTML and JS implementation that prints 'GitHub MCP server POC' to the page. Follows best practices for separation of concerns and DOM manipulation.